### PR TITLE
chore: set up github token

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,3 +23,4 @@ jobs:
         run: npx semantic-release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Needed for semantic release, see [docs](https://github.com/semantic-release/semantic-release/blob/971a5e0d16f1a32e117e9ce382a1618c8256d0d9/docs/recipes/github-actions.md). The [built-in token](https://docs.github.com/en/actions/reference/authentication-in-a-workflow) should be all we need.

P.S. The repo is missing an NPM_TOKEN [secret](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).